### PR TITLE
Ignore html (`<br>`) tags in the news title on the homepage

### DIFF
--- a/public/theme/boltcms-2021/index.twig
+++ b/public/theme/boltcms-2021/index.twig
@@ -91,7 +91,7 @@
         <div class="columns sticky-news">
             {% for newsitem in news %}
                 <div>
-                    <h2>{{ newsitem.title }}</h2>
+                    <h2>{{ newsitem|title }}</h2>
                     <p>{{ newsitem.content|excerpt }}</p>
                     <a href="{{ newsitem|link }}">Read the announcement</a>
                 </div>


### PR DESCRIPTION
Hi @mcdennem , I added the possibility to add a `<br>` tag after the emoji for news titles. But the on the homepage it looks a bit broken see: https://boltcms.io/

This PR fixes it :-)